### PR TITLE
binclude: fix printf and snprintf calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ $(BLASTEM):
 $(MEGALOADER):
 	@$(CC_HOST) -D_DEFAULT_SOURCE util/megaloader.c -o $(MEGALOADER) -O3 -std=c11
 
-$(BINCLUDE):
-	@$(CC_HOST) util/binclude.c -o $(BINCLUDE) -O3 -std=c11
+$(BINCLUDE): util/binclude.c
+	@$(CC_HOST) $^ -o $(BINCLUDE) -O3 -std=c11
 
 $(OUTPUT_FILE).bin: $(OUTPUT_FILE).elf
 	@$(OBJCOPY) -O binary $< temp.bin

--- a/util/binclude.c
+++ b/util/binclude.c
@@ -41,8 +41,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	snprintf(out_fpath, 512, "%s.c", symbol_name);
-
+	snprintf(out_fpath, sizeof(out_fpath) - 1, "%s.c", symbol_name);
+	out_fpath[sizeof(out_fpath) - 1] = 0;
 	fout = fopen(out_fpath, "w");
 	if (!fout)
 	{
@@ -81,10 +81,11 @@ int main(int argc, char **argv)
 	fclose(fout);
 	fclose(fin);
 
-	printf("Wrote %d bytes to \"%s\".\n", bytes_written, out_fpath);
+	printf("Wrote %zu bytes to \"%s\".\n", bytes_written, out_fpath);
 
 	// Write header file
-	snprintf(out_fpath, 512, "%s.h", symbol_name);
+	snprintf(out_fpath, sizeof(out_fpath) - 1, "%s.h", symbol_name);
+	out_fpath[sizeof(out_fpath) - 1] = 0;
 	fout = fopen(out_fpath, "w");
 	if (!fout)
 	{


### PR DESCRIPTION
- binclude.c: Change format of written length from `%d` to `%zu`
- binclude.c: ensure path string is terminated
- Makefile: Have util/binclude depend on its source file

Because `int` and `size_t` are different types, GCC's `printf` format
string checking warns when attempting to print one as the other.
```
util/binclude.c: In function ‘main’:
util/binclude.c:84:17: warning: format ‘%d’ expects argument of type
    ‘int’, but argument 2 has type ‘size_t {aka long unsigned int}’
    [-Wformat=]
  printf("Wrote %d bytes to \"%s\".\n", bytes_written, out_fpath);
                ~^
                %ld
```
So instead of `%d` which means `int`, use C99's `%zu` which means `size_t`.
https://stackoverflow.com/q/2524611/2738262

But when I made this change, binclude didn't automatically rebuild:
```
$ make util/binclude
make: 'util/binclude' is up to date.
```
I found and fixed a missing prerequisite in the makefile.

Finally, `snprintf` does not NUL terminate the result if the result is
exactly as long as the buffer.  Work around this by passing 1 less
than the length of the buffer and explicitly write the terminator.