### PR TITLE
Consolidate free VRAM space

### DIFF
--- a/common/src/md/vdp.h
+++ b/common/src/md/vdp.h
@@ -48,9 +48,12 @@ MIchael Moffitt 2018 */
 #define VDP_STATUS_FULL 0x0100
 #define VDP_STATUS_EMPTY 0x0200
 
-#define VRAM_SCRA_BASE	0xA000
-#define VRAM_SCRB_BASE	0xC000
-#define VRAM_SCRW_BASE	0xF000
+// Default VRAM layout, assuming 64x32-cell planes
+// 0000-BFFF (1536 tiles) free
+#define VRAM_SCRA_BASE	0xC000
+#define VRAM_SCRW_BASE	0xD000
+#define VRAM_SCRB_BASE	0xE000
+// F000-F7FF (64 tiles) free
 #define VRAM_HSCR_BASE	0xF800
 #define VRAM_SPR_BASE	0xFC00
 


### PR DESCRIPTION
The current VRAM map:

    0000-9FFF: Free
    A000-AFFF: Plane A (64x32)
    B000-BFFF: Free
    C000-CFFF: Plane B (64x32)
    D000-EFFF: Free
    F000-FFFF: Window (64x16)
    F800-FB7F: Hscroll table
    FC00-FE7F: SAT

The new one allows for a right side window and a larger contiguous area for character data:

    0000-BFFF: Free
    C000-CFFF: Plane A (64x32)
    D000-DFFF: Window (64x32)
    E000-EFFF: Plane B (64x32)
    F000-F7FF: Free
    F800-FB7F: Hscroll table
    FC00-FE7F: SAT