### PR TITLE
minor optimization to tmss.s

### DIFF
--- a/mdk/src/md/tmss.s
+++ b/mdk/src/md/tmss.s
@@ -2,8 +2,8 @@
 
 md_tmss_init:
 	/* poke TMSS */
-	move.b	0xa10001, d0
-	andi.b	#0x0F, d0
+	moveq	#0x0F, d0
+	and.b	0xa10001, d0
 	beq	.tmss_version_0
 	move.l	#0x53454741, 0xa14000
 .tmss_version_0:


### PR DESCRIPTION
using moveq #0x0F,d0 followed by AND from memory saves 2 bytes and 4 cycles. this has no adverse effects as far as I'm aware.